### PR TITLE
Changed item example in NPC Dialogue

### DIFF
--- a/docs/entities/npc-dialogs.md
+++ b/docs/entities/npc-dialogs.md
@@ -265,8 +265,9 @@ Lastly, create an item that will open the dialog when right-clicked/interacted w
       "open_menu":{
         "run_command":{
           "command":[
-            "dialogue open @e[type=npc,c=1] @p main_teleport_menu"
-          ]
+            "dialogue open @e[type=npc,c=1] @s main_teleport_menu"
+          ],
+          "target": "player"
         }
       }
     }


### PR DESCRIPTION
This version of the item example will target the player that uses the item and will not try to find the nearest player.