### PR TITLE
Update runtime-identifier.md

### DIFF
--- a/docs/entities/runtime-identifier.md
+++ b/docs/entities/runtime-identifier.md
@@ -178,6 +178,12 @@ Perfect for imitating a block, as long as the player is in Adventure Mode.
 
 ---
 
+### minecraft:wolf
+
+-   Prevents some components like minecraft:target_nearby_sensor from ignoring entity owner status.
+
+---
+
 ### minecraft:zombie
 
 -   Makes the entity receive damage from Healing effect, heal from Instant Damage effect and become immune to Regeneration and Poison effect


### PR DESCRIPTION
Added some information about runtime_identifier for wolves. This was discovered when target_nearby_sensor on an entity was causing my mob to continue to fight a mob that i also owned. Making it a wolf prevented this behavior.