### PR TITLE
added timeout_cooldown to component hide

### DIFF
--- a/docs/entities/vanilla-usage-components.md
+++ b/docs/entities/vanilla-usage-components.md
@@ -5588,7 +5588,8 @@ This documentation is stripped from the vanilla files using an automated script.
     "priority": 0,
     "speed_multiplier": 0.8,
     "poi_type": "bed",
-    "duration": 30.0
+    "duration": 30.0,
+	"timeout_cooldown": 8.0
 }
 ```
 


### PR DESCRIPTION
The field `timeout_cooldown ` was missing in the component `minecraft:behavior.hide` with a default value of 8.0.  My source is the documentation within the vanilla behaviour-pack. It's not used in a vanilla entity though. 