### PR TITLE
Improve max_/min_distance sound key explanations

### DIFF
--- a/docs/concepts/sounds.md
+++ b/docs/concepts/sounds.md
@@ -50,6 +50,21 @@ Sounds added in this way can be triggered using `/playsound`. Please note that `
 New files referenced by file path, such as sounds, DO need a complete client restart to load. This means that if sounds don't work, you should restart your entire MC client rather than just reloading the world.
 :::
 
+### playsound volume notes
+
+The game will clamp the sound volume to at most 1.0 before multiplying it with the sound definition's 
+
+For `/playsound`, the maximum hearable range of a sound is given by `min(max_distance, max(volume * 16, 16))`.
+If `"max_distance"`is not given in the sound's definition, it is equivalent to `volume * 16`.
+
+**Attenuation by distance** of the hearable sound's volume is not affected by the volume parameter given in the command.
+
+For example, `mob.ghast.affectionate_scream` sets `"min_distance": 100.0`, but can only be heard from at most 16 blocks away when using `/playsound` to play it.
+However when using a large enough volume to hear the sound farther away, the sound will get quieter only after a distance of more than 100.0.
+
+To make a sound which can be heard far away but also drops in volume continuously over distance, one can add e.g. `"volume": 0.01`and use large `<volume>` values in the playsound command. The high value for the `/playsound` volume will produce a large hearable range (e.g. a volume of 4 is 64 blocks as calculated above), while the low volume will prevent the played sound from capping at 1.0 too soon.
+
+
 ### Top Level Keys
 
 In the example above, I showed two `top-level` fields: `category` and `sounds`. Sounds will be discussed in further detail below, but the other `top-level` keys will be discussed here:

--- a/docs/concepts/sounds.md
+++ b/docs/concepts/sounds.md
@@ -73,11 +73,11 @@ Categories are used internally by the engine to decide how each sound is played.
 
 #### min_distance
 
-The minimum distance **away** the source of the sound that the client needs to be within to hear. It must be a float (1.0), or the argument will be ignored.
+The distance from the sound source after which sound volume is attenuated. Default value: 0.0. It must be a float (eg. 1.0), or the property will be ignored.
 
 #### max_distance
 
-The maximum distance **to** the source of the client's sound needs to be within to hear. It must be a float (1.0), or the argument will be ignored.
+The distance from the sound source after which the sound volume is the quietest (if in range). It must be a float (eg. 1.0), or the property will be ignored.
 
 ### Sound definitions
 


### PR DESCRIPTION
Note that if you want to test this behavior using `/playsound`, that the `minimumVolume` parameter is only simulated by the server by sending the sound in a different position than given, to achieve desired attenuation (which is calculated only on the server).

### Further reading
https://bugs.mojang.com/browse/MCPE-35222: "min_distance sets the distance in blocks at which a sound begins to attenuate."
https://bugs.mojang.com/browse/MCPE-14420: "The "min_distance" : 1.5 makes the attenuation begin at 1.5 blocks from the source."