### PR TITLE
Seperating Loot Tables and Spawn Rules

### DIFF
--- a/docs/entities/spawn_rules.md
+++ b/docs/entities/spawn_rules.md
@@ -79,19 +79,3 @@ Spawn rules define how vanilla Entities and custom entities spawn. In the next c
     `"event_skip_count": 2`, for example, means that the first two entities will not be spawned with this event, but all the next ones will.
 
 _Why not create some more custom blocks, items, and loot tables before moving onto the next big chapter?_
-
----
-
----
-
-
-## Your progress so far
-
-**What you've done:**
-
--   [x] Learned to create spawn rules;
--   [x] Learned about the usefulness referencing the Example files and the documentation even better;
-
-**What are you to do next:**
-
--   [ ] **Create. Custom. Entities.**

--- a/docs/entities/spawn_rules.md
+++ b/docs/entities/spawn_rules.md
@@ -1,0 +1,97 @@
+---
+title: Spawn Rules
+---
+
+Spawn rules define how vanilla Entities and custom entities spawn. In the next chapter we'll be creating a custom entity, so make sure to prepare a custom spawn rule for it! Check out the vanilla example files for more information. ;)
+
+<CodeHeader>BP/spawn_rules/zombie.json</CodeHeader>
+
+```json
+{
+	"format_version": "1.8.0",
+	"minecraft:spawn_rules": {
+		"description": {
+			"identifier": "minecraft:zombie",
+			"population_control": "monster"
+		},
+		"conditions": [
+			{
+				"minecraft:spawns_on_surface": {},
+				"minecraft:spawns_underground": {},
+				"minecraft:brightness_filter": {
+					"min": 0,
+					"max": 7,
+					"adjust_for_weather": true
+				},
+				"minecraft:difficulty_filter": {
+					"min": "easy",
+					"max": "hard"
+				},
+				"minecraft:weight": {
+					"default": 100
+				},
+				"minecraft:herd": {
+					"min_size": 2,
+					"max_size": 4
+				},
+				"minecraft:permute_type": [
+					{
+						"weight": 95
+					},
+					{
+						"weight": 5,
+						"entity_type": "minecraft:zombie_villager"
+					}
+				],
+				"minecraft:biome_filter": {
+					"test": "has_biome_tag",
+					"operator": "==",
+					"value": "monster"
+				}
+			}
+		]
+	}
+}
+```
+
+-   "`description`">"`identifier`": the entity to spawn
+-   "`population_control`": controls spawning and despawning quantities. Can be set to "`animal`", "`underwater_animal`", "`monster`" and "`ambient`".
+-   "`conditions`" are a list of conditions that have to be met in order for the spawn attempt to succeed.
+-   "`minecraft:spawns_on_surface`", "`minecraft:spawns_underground`" and "`minecraft:spawns_underwater`" control where the entity spawns cap-wise.
+-   "`minecraft_brightness_filter`" can be set from 0 to 15 and controls in which light levels can entities spawn. - "`adjust_for_weather`" defines whether it light levels are counted lower during rain or thunder weather.
+-   "`minecraft:difficulty_filter`" sets the range of level difficulty to enable this entity's spawns.
+-   "`minecraft:herd`" sets the number of entities spawning together, on the same spawn rule.
+-   "`minecraft:permute_type`" with "`weight`"s and "`entity_type`"s sets a chance for the spawned entity to mutate into a different one.
+-   And, lastly, "`minecraft:biome_filter`" tests for certain biome tags. Look up the filter syntax and list of biome tags in the documentation or search examples in the vanilla Example pack.
+
+<CodeHeader></CodeHeader>
+
+```json
+"minecraft:herd": {
+          "min_size": 1,
+          "max_size": 2,
+          "event":"minecraft:entity_born",
+          "event_skip_count": 1
+        },
+```
+
+-   "`minecraft:herd`" can also be used like this to make the second entity spawned [in this scenario] with the "`minecraft:entity_born`" (as baby). Can be used in any event.
+    `"event_skip_count": 2`, for example, means that the first two entities will not be spawned with this event, but all the next ones will.
+
+_Why not create some more custom blocks, items, and loot tables before moving onto the next big chapter?_
+
+---
+
+---
+
+
+## Your progress so far
+
+**What you've done:**
+
+-   [x] Learned to create spawn rules;
+-   [x] Learned about the usefulness referencing the Example files and the documentation even better;
+
+**What are you to do next:**
+
+-   [ ] **Create. Custom. Entities.**

--- a/docs/loot/loot_tables.md
+++ b/docs/loot/loot_tables.md
@@ -373,17 +373,3 @@ _Blocks do not drop loot in creative mode_
 **Note: it is possible to generate loot tables visually online. Check Links and Contact for the link to a reliable generator.**
 
 **_Challenge: Create custom loot tables for our custom blocks created in the previous chapter!_**
-
----
-
----
-
-## Your progress so far
-
-**What you've done:**
-
--   [x] Learned to create Loot Tables;
--   [x] Learned to create spawn rules;
--   [x] Created Loot Tables for our custom blocks and items;
--   [x] Learned about the usefulness referencing the Example files and the documentation even better;
--   [x] Tried out some online file generators;

--- a/docs/loot/loot_tables.md
+++ b/docs/loot/loot_tables.md
@@ -1,5 +1,5 @@
 ---
-title: Loot Tables and Spawn Rules
+title: Loot Tables
 ---
 
 Loot tables are powerful tools that define what blocks drop upon destruction, what entities upon death, what equipment can entities use, what can a player fish out of a river and what loot ends up in the game's loot chests. In order to understand loot tables better, I recommend looking into the `loot_tables` folder of the Example Vanilla Behavior pack, but I'll trow in some examples from there into here nevertheless. \
@@ -378,90 +378,6 @@ _Blocks do not drop loot in creative mode_
 
 ---
 
-## Spawn Rules
-
-Spawn rules define how vanilla Entities and custom entities spawn. In the next chapter we'll be creating a custom entity, so make sure to prepare a custom spawn rule for it! Check out the vanilla example files for more information. ;)
-
-<CodeHeader>BP/spawn_rules/zombie.json</CodeHeader>
-
-```json
-{
-	"format_version": "1.8.0",
-	"minecraft:spawn_rules": {
-		"description": {
-			"identifier": "minecraft:zombie",
-			"population_control": "monster"
-		},
-		"conditions": [
-			{
-				"minecraft:spawns_on_surface": {},
-				"minecraft:spawns_underground": {},
-				"minecraft:brightness_filter": {
-					"min": 0,
-					"max": 7,
-					"adjust_for_weather": true
-				},
-				"minecraft:difficulty_filter": {
-					"min": "easy",
-					"max": "hard"
-				},
-				"minecraft:weight": {
-					"default": 100
-				},
-				"minecraft:herd": {
-					"min_size": 2,
-					"max_size": 4
-				},
-				"minecraft:permute_type": [
-					{
-						"weight": 95
-					},
-					{
-						"weight": 5,
-						"entity_type": "minecraft:zombie_villager"
-					}
-				],
-				"minecraft:biome_filter": {
-					"test": "has_biome_tag",
-					"operator": "==",
-					"value": "monster"
-				}
-			}
-		]
-	}
-}
-```
-
--   "`description`">"`identifier`": the entity to spawn
--   "`population_control`": controls spawning and despawning quantities. Can be set to "`animal`", "`underwater_animal`", "`monster`" and "`ambient`".
--   "`conditions`" are a list of conditions that have to be met in order for the spawn attempt to succeed.
--   "`minecraft:spawns_on_surface`", "`minecraft:spawns_underground`" and "`minecraft:spawns_underwater`" control where the entity spawns cap-wise.
--   "`minecraft_brightness_filter`" can be set from 0 to 15 and controls in which light levels can entities spawn. - "`adjust_for_weather`" defines whether it light levels are counted lower during rain or thunder weather.
--   "`minecraft:difficulty_filter`" sets the range of level difficulty to enable this entity's spawns.
--   "`minecraft:herd`" sets the number of entities spawning together, on the same spawn rule.
--   "`minecraft:permute_type`" with "`weight`"s and "`entity_type`"s sets a chance for the spawned entity to mutate into a different one.
--   And, lastly, "`minecraft:biome_filter`" tests for certain biome tags. Look up the filter syntax and list of biome tags in the documentation or search examples in the vanilla Example pack.
-
-<CodeHeader></CodeHeader>
-
-```json
-"minecraft:herd": {
-          "min_size": 1,
-          "max_size": 2,
-          "event":"minecraft:entity_born",
-          "event_skip_count": 1
-        },
-```
-
--   "`minecraft:herd`" can also be used like this to make the second entity spawned [in this scenario] with the "`minecraft:entity_born`" (as baby). Can be used in any event.
-    `"event_skip_count": 2`, for example, means that the first two entities will not be spawned with this event, but all the next ones will.
-
-_Why not create some more custom blocks, items, and loot tables before moving onto the next big chapter?_
-
----
-
----
-
 ## Your progress so far
 
 **What you've done:**
@@ -471,7 +387,3 @@ _Why not create some more custom blocks, items, and loot tables before moving on
 -   [x] Created Loot Tables for our custom blocks and items;
 -   [x] Learned about the usefulness referencing the Example files and the documentation even better;
 -   [x] Tried out some online file generators;
-
-**What are you to do next:**
-
--   [ ] **Create. Custom. Entities.**


### PR DESCRIPTION
Separating Loot Tables and Spawn Rules, Move the Spawn Rules from Loot section into Entity Section