### PR TITLE
fix the hyperlink for PodrumR3 - server softwares list

### DIFF
--- a/docs/servers/server-software.md
+++ b/docs/servers/server-software.md
@@ -66,7 +66,7 @@ Alongside the Vanilla BDS offering, many community projects exist, in a variaty 
 
 ### Python
 
--   [Podrum](https://github.com/Podrum/Podrum)
+-   [PodrumR3](https://github.com/Podrum/PodrumR3)
 
 ## Discontinued Software
 


### PR DESCRIPTION
it's moved to new link.