### PR TITLE
Divided Android versions for file storage location

### DIFF
--- a/docs/guide/project-setup.md
+++ b/docs/guide/project-setup.md
@@ -19,7 +19,9 @@ You should create a shortcut to the `com.mojang` folder on your Desktop or on yo
 
 ### Android
 
-`Phone > games > com.mojang`
+Android 11 or older: `Phone > games > com.mojang`
+
+Android 12 and newer: `Phone > Android > data > com.mojang.minecraftpe > files > games > com.mojang`
 
 ### iOS
 


### PR DESCRIPTION
Android 12's Scoped Storage policy resulted in Minecraft's storage moving to the Android/Data folder. Due to this change, it should be noted where these files are now located.