### PR TITLE
Fix spelling mistake in emojis.md

### DIFF
--- a/docs/concepts/emojis.md
+++ b/docs/concepts/emojis.md
@@ -31,7 +31,7 @@ There will be instructions for creating custom emoji at the bottom.
 | Name        | Letter (Copy/Paste This) | Unicode | Image                                                      |
 | ----------- | ------------------------ | ------- | ---------------------------------------------------------- |
 | Jump        |                         | U+E084  | ![](/assets/images/concepts/emojis/mobile/jump.png)        |
-| Couch       |                         | U+E085  | ![](/assets/images/concepts/emojis/mobile/crouch.png)      |
+| Crouch      |                         | U+E085  | ![](/assets/images/concepts/emojis/mobile/crouch.png)      |
 | Fly Up      |                         | U+E086  | ![](/assets/images/concepts/emojis/mobile/fly_up.png)      |
 | Fly Down    |                         | U+E087  | ![](/assets/images/concepts/emojis/mobile/fly_down.png)    |
 | Left Arrow  |                         | U+E081  | ![](/assets/images/concepts/emojis/mobile/left_arrow.png)  |


### PR DESCRIPTION
Line 34: "Couch" changed to "Crouch". If this spelling mistake is in the game and therefore intended, it would be nice to add a remark for that.
I don't know why GitHub shows that line 209 changed as I did not touch it.