### PR TITLE
Updated query.movement_direction

### DIFF
--- a/docs/documentation/queries.md
+++ b/docs/documentation/queries.md
@@ -505,17 +505,26 @@ Identical behavior to `variable.short_arm_offset_right` except it references the
 
 ## query.movement_direction
 
-Essentially, returns the ratio between speed in the specified argument, over the total speeds in all 3 axis combined. For example, you are moving 5 blocks/second in the x-axis, 0 blocks/second in the y-axis, and 3 blocks/second in the z-axis -> `5 / ( 5 + 0 + 3 ) = 0.625`.
+Returns one of the 3 components from the normalized vector of the entity movement meaning the magnitude/modulus/length of the vector is between 0 and 1.
+
+**Note**: As of writing the documentation, the value returned from any of the axis will change depending on the speed of the entity (If the entity is on the ground the value will be less than the value of the entity if it were in the air even if it is moving in the same direction).
+
+To get the actual normalized velocity vector of the entity movement you will have to normalize the values. Here is the MoLang setup:
+
+```
+variable.mag = math.sqrt( math.pow( query.movement_direction(0), 2 ) + math.pow( query.movement_direction(1), 2) + math.pow( query.movement_direction(2), 2));
+variable.xNorm = query.movement_direction(0) / variable.mag;
+variable.yNorm = query.movement_direction(1) / variable.mag;
+variable.zNorm = query.movement_direction(2) / variable.mag;
+```
+
+For more information on normalized vectors you can play around with this <a href=https://www.desmos.com/calculator/hhoamwgve2>Desmos graph<a> 
 
 | Argument | Axis |
 | -------- | ---- |
 | 0        | X    |
 | 1        | Y    |
 | 2        | Z    |
-
-If stationary, the values will return as `0`. When you are moving along the positive X/Y/Z axis, the returned value is positive. If you are moving in the opposite direction, the returned value is negative. The return value should never exceed `1` or `-1`.
-
-It's worth noting that the `Y` axis may not work as expected. When you stay in the same spot, and are not hovering, the query returns `-1`. When you stay on the same X and Z coordinates and move downwards on the Y axis, the query also returns `-1`. If you are hovering on a constant Y coordinate, it returns `0`.
 
 ## query.block_neighbor_has_any_tag and query.relative_block_has_any_tag
 


### PR DESCRIPTION
fixed the formula used by the movement direction query to be the correct formula which is the unit vector formula and not a/(a+b+c) and also added more information on the query