### PR TITLE
Fix tellraw command example

### DIFF
--- a/docs/commands/tellraw.md
+++ b/docs/commands/tellraw.md
@@ -112,11 +112,11 @@ language files:
 <CodeHeader></CodeHeader>
 
 ```
-example.langcode.2=The winner is: %%s. With a score of %%s
+example.langcode.2=The winner is: %s. With a score of %s
 ```
 
 <CodeHeader></CodeHeader>
 
 ```json
-/tellraw @a {"translate": [{"text": "example.langcode.2", "with": {"rawtext": [{"selector": "@a[r=5,c=1]"}, {"text": "§6With a score of: "}, {"score":{"name": "@s","objective": "value"}}]}}]}
+/tellraw @a {"rawtext":[{"translate":"example.langcode.2","with":{"rawtext":[{"selector":"@a[r=5,c=1]"},{"text":"§6With a score of: "},{"score":{"name":"@s","objective":"value"}}]}}]}
 ```

--- a/docs/commands/tellraw.md
+++ b/docs/commands/tellraw.md
@@ -101,7 +101,7 @@ The command:
 <CodeHeader></CodeHeader>
 
 ```json
-tellraw @a { "rawtext": [ { "translate": "example.langcode.1" } ] }
+/tellraw @a { "rawtext": [ { "translate": "example.langcode.1" } ] }
 ```
 
 


### PR DESCRIPTION
The tellraw with translation and selectors/scores gives error when executed in game.
The example follows the one made by @Sprunkles#2335 [on Discord](https://discord.com/channels/523663022053392405/525078985676161024/1014924673261244436) (Bedrock Add-Ons). 
The `%%s` have been modified following a test I made.