### PR TITLE
Add first community resource pack

### DIFF
--- a/docs/meta/useful-links.md
+++ b/docs/meta/useful-links.md
@@ -89,6 +89,7 @@ These packs are maintained and published by Mojang.
 
 These packs are published by the open-source community
 
+-   [wiki-addon](https://github.com/Bedrock-OSS/wiki-addon)
 -   [Enchantment Details](https://github.com/supercam19/EnchantmentDetails)
 
 ## Scripting Resources

--- a/docs/meta/useful-links.md
+++ b/docs/meta/useful-links.md
@@ -79,11 +79,17 @@ Important links have a ⭐.
 
 ## Behavior & Resource Packs
 
+These packs are maintained and published by Mojang.
+
 -   ⭐ [Vanilla Resource Pack](https://aka.ms/resourcepacktemplate)
 -   ⭐ [Vanilla Behavior Pack](https://aka.ms/behaviorpacktemplate)
 -   [Vanilla Resource Pack (BETA)](https://aka.ms/MinecraftBetaResources)
 -   [Vanilla Behavior Pack (BETA)](https://aka.ms/MinecraftBetaBehaviors)
 -   [Pack Archive (old versions)](https://bedrock.dev/packs)
+
+These packs are published by the open-source community
+
+-   [Enchantment Details](https://github.com/supercam19/EnchantmentDetails)
 
 ## Scripting Resources
 


### PR DESCRIPTION
Well-maintained community resource packs will serve as a good reference for folks just getting started. Long-term, this page can be split if the list is big enough.