### PR TITLE
Add warning to old Scripting APIs

### DIFF
--- a/docs/.vitepress/theme/Components/Pages/Homepage.vue
+++ b/docs/.vitepress/theme/Components/Pages/Homepage.vue
@@ -114,10 +114,10 @@
 					title="Scripting"
 					imgsrc="assets/images/homepage/scripting.png"
 				>
-					<a href="scripting/scripting-intro.html">Beginner's Guide</a
-					>: Learn the basics of the legacy scripting-API<br /><br />
-					<a href="scripting/game-tests.html">Game Test Framework</a>:
-					Learn about the new scripting-API!
+					<a href="scripting/game-tests.html">Beginner's Guide</a
+					>: Learn the basics of the experimental scripting-API<br /><br />
+					<a href="scripting/custom-command.html">Custom commands</a>:
+					Learn how to make your own custom commands!
 				</Card>
 				<Card
 					title="World Generation"

--- a/docs/scripting/custom-command.md
+++ b/docs/scripting/custom-command.md
@@ -1,6 +1,8 @@
 ---
 title: Simple Custom Commands
 category: Game Tests
+tags:
+    - experimental
 ---
 
 Who doesn't want any custom command? Me neither. With Gametest, you can create your custom command. This article, we will create your own custom command using Gametest.

--- a/docs/scripting/game-tests.md
+++ b/docs/scripting/game-tests.md
@@ -8,6 +8,9 @@ tags:
 ::: tip
 The GameTest framework requires you to activate **"Enable GameTest Framework"** or **"GameTest Framework"** in your world settings, and you must be using **Minecraft 1.16.210.60 beta or above**.
 :::
+::: warning
+As of Beta 1.19.40.23 the whole scripting APIs will receive some breaking changes. 
+:::
 
 GameTests are a new feature that allows developers to create unit tests to make it easier to test if game mechanics work. They are built with javascript files in the behavior pack folder, and each file can register multiple GameTests. Each registered GameTest must also have a .mcstructure file in the `BP/structures` folder.
 The API can also be used for creations outside of creating unit tests by just using the `"mojang-minecraft"` module, though this is currently limited.

--- a/docs/scripting/gametest-form.md
+++ b/docs/scripting/gametest-form.md
@@ -1,6 +1,8 @@
 ---
 title: Gametest Form
 category: Game Tests
+tags:
+    - experimental
 ---
 
 Minecraft 1.18.30 released new wonderful module, `mojang-minecraft-ui`. With that module, we can create form ui without need JSON-UI.

--- a/docs/scripting/saving-loading.md
+++ b/docs/scripting/saving-loading.md
@@ -6,6 +6,12 @@ tags:
     - recipe
 ---
 
+:::danger Stop!
+
+This scripting API is no longer supported. Refer to the new [Scripting API](/scripting/game-tests.html).
+
+:::
+
 Saving and loading data in Bedrock is tricky because scripts cannot access the local file system directly.
 
 Nonetheless, we can save data by [tagging](https://www.youtube.com/watch?v=tjragqkAlMc) a [dummy entity](/entities/dummy-entities).

--- a/docs/scripting/scripting-intro.md
+++ b/docs/scripting/scripting-intro.md
@@ -8,7 +8,7 @@ tags:
 
 :::danger Stop!
 
-Scripting API is no longer supported.
+This scripting API is no longer supported. Refer to the new [Scripting API](/scripting/game-tests.html).
 
 :::
 

--- a/docs/scripting/typescript.md
+++ b/docs/scripting/typescript.md
@@ -3,6 +3,12 @@ title: TypeScript
 category: Legacy Scripting
 ---
 
+:::danger Stop!
+
+This scripting API is no longer supported. Refer to the new [Scripting API](/scripting/game-tests.html).
+
+:::
+
 [//]: # 'Documentation is heavily based on https://minecraft-addon-tools.github.io/tutorials/getting-started'
 
 [TypeScript](https://www.typescriptlang.org/) is a programming language developed and maintained by Microsoft. It is a strict syntactical superset of JavaScript and adds optional static typing to the language. TypeScript is designed for the development of large applications and transcompiles to JavaScript. As TypeScript is a superset of JavaScript, existing JavaScript programs are also valid TypeScript programs.


### PR DESCRIPTION
Still not ready. 
~~I think I'll rewrite the tutorial for typescript for the new framework.~~ Because of the breaking changes I'm going to wait for it to get out of Experimental, for now just the warnings are good.