### PR TITLE
Update block-shapes.md

### DIFF
--- a/docs/blocks/block-shapes.md
+++ b/docs/blocks/block-shapes.md
@@ -27,34 +27,6 @@ They are added in the resource pack's file, `blocks.json`, using child `"blocksh
 
 ```
 
-## Known Issues
-
-Currently, blockshapes do **not** work for custom blocks through the usage of 1 resource pack, it just doesn't work. Although by utilising the hierarchy system of active resource packs, you may spread the contents of `blocks.json` over 2 separate resource packs, allowing for blockshapes to be applied.
-
-Example of `blocks.json` from first pack:
-
-```json
-
-   "wiki:void_fire": {
-       "sound": "stone",
-       "textures": "void_fire"
-   }
-
-```
-
-Example of `blocks.json` from second pack:
-
-```json
-
-   "wiki:void_fire": {
-       "blockshape": "fire"
-   }
-
-```
-
-All that is required of the second pack is to contain the information relevant to and to define the blockshape of the custom block, so the only required files in the pack are `manifest.json` and `blocks.json`. Then when it comes to applying the addon to your world, make sure to have the second resource pack **above** the first in the hierarchy.
-
-The exact reason for this issue is unknown.
 
 ## List of known Blockshapes
 


### PR DESCRIPTION
Workaround of setting Blockshape for Custom Blocks through a second resource pack no longer works.