### PR TITLE
Fix Hacktoberfest logo in dark mode

### DIFF
--- a/docs/.vitepress/theme/Components/Content/Card.vue
+++ b/docs/.vitepress/theme/Components/Content/Card.vue
@@ -1,7 +1,8 @@
 <template>
 	<div class="card">
         <div class="flex justify-start items-center flex-row flex-nowrap mb-4">
-            <img :src="imgLink" class="object-contain mr-4 filter drop-shadow" style="max-height: 56px;">
+			<img v-if='currentTheme === "dark"' :src="imgsrcDark" class="object-contain mr-4 filter drop-shadow" style="max-height: 56px;">
+			<img v-if='currentTheme === "light"' :src="imgsrcLight" class="object-contain mr-4 filter drop-shadow" style="max-height: 56px;">
             <h2 style="margin: 0 !important;">{{ title }}</h2>
         </div>
         <p><slot/></p>
@@ -21,6 +22,6 @@ const props = defineProps<{
 	imgsrcDark?: string
 
 }>();
-
-const imgLink = import.meta.env.BASE_URL + (currentTheme.value === "dark" && props.imgsrcDark ? props.imgsrcDark : props.imgsrcLight);
+const imgsrcLight = import.meta.env.BASE_URL + props.imgsrcLight;
+const imgsrcDark = import.meta.env.BASE_URL + (props.imgsrcDark ? props.imgsrcDark : props.imgsrcLight);
 </script>

--- a/docs/.vitepress/theme/Components/Content/Card.vue
+++ b/docs/.vitepress/theme/Components/Content/Card.vue
@@ -22,6 +22,7 @@ const props = defineProps<{
 	imgsrcDark?: string
 
 }>();
+// Hotfix for making it work.
 const imgsrcLight = import.meta.env.BASE_URL + props.imgsrcLight;
 const imgsrcDark = import.meta.env.BASE_URL + (props.imgsrcDark ? props.imgsrcDark : props.imgsrcLight);
 </script>

--- a/docs/.vitepress/theme/Components/Content/CardLink.vue
+++ b/docs/.vitepress/theme/Components/Content/CardLink.vue
@@ -23,6 +23,7 @@ const props = defineProps<{
 	imgsrcLight: string,
 	imgsrcDark?: string
 }>();
+// Hotfix for making it work.
 const imgsrcLight = import.meta.env.BASE_URL + props.imgsrcLight;
 const imgsrcDark = import.meta.env.BASE_URL + (props.imgsrcDark ? props.imgsrcDark : props.imgsrcLight);
 </script>

--- a/docs/.vitepress/theme/Components/Content/CardLink.vue
+++ b/docs/.vitepress/theme/Components/Content/CardLink.vue
@@ -1,7 +1,8 @@
 <template>
 	<div class="card">
         <div class="flex justify-start items-center flex-row flex-nowrap mb-4">
-            <img :src="imgLink" class="object-contain mr-4 filter drop-shadow" style="max-height: 56px;">
+            <img v-if='currentTheme === "dark"' :src="imgsrcDark" class="object-contain mr-4 filter drop-shadow" style="max-height: 56px;">
+			<img v-if='currentTheme === "light"' :src="imgsrcLight" class="object-contain mr-4 filter drop-shadow" style="max-height: 56px;">
             <h2 style="margin: 0 !important;">
                 <a :href="props.link">{{ title }}</a>
             </h2>
@@ -21,7 +22,7 @@ const props = defineProps<{
 	link: string,
 	imgsrcLight: string,
 	imgsrcDark?: string
-
 }>();
-const imgLink = import.meta.env.BASE_URL + (currentTheme.value === "dark" && props.imgsrcDark ? props.imgsrcDark : props.imgsrcLight);
+const imgsrcLight = import.meta.env.BASE_URL + props.imgsrcLight;
+const imgsrcDark = import.meta.env.BASE_URL + (props.imgsrcDark ? props.imgsrcDark : props.imgsrcLight);
 </script>


### PR DESCRIPTION
Apparently vitepress doesn't work the same on dev and prod mode. This should fix the logo when using dark mode