### PR TITLE
Link embed

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-	"recommendations": ["johnsoncodehk.volar"]
+	"recommendations": ["Vue.volar"]
 }

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -304,7 +304,7 @@ module.exports = (async function () {
 				{
 					rel: 'icon',
 					href: '/assets/images/favicons/apple-touch-icon.png',
-					sizes: '180x180'
+					sizes: '180x180',
 				},
 			],
 			[
@@ -312,22 +312,45 @@ module.exports = (async function () {
 				{
 					rel: 'icon',
 					href: '/assets/images/favicons/safari-pinned-tab.svg',
-					color: '#60c3fa'
+					color: '#60c3fa',
 				},
 			],
 			[
 				'meta',
 				{
 					name: 'viewport',
-					content: 'width=device-width,initial-scale=1'
-				}
+					content: 'width=device-width,initial-scale=1',
+				},
 			],
+
 			[
 				'meta',
 				{
 					name: 'theme-color',
-					content: '#60c3fa'
-				}
+					content: '#60c3fa',
+				},
+			],
+			// open graph metadata: used for link previews in eg. discord
+			[
+				'meta',
+				{
+					property: 'og:type',
+					content: 'website',
+				},
+			],
+			[
+				'meta',
+				{
+					property: 'og:site_name',
+					content: 'Bedrock Wiki',
+				},
+			],
+			[
+				'meta',
+				{
+					property: 'og:image',
+					content: '/favicon.ico',
+				},
 			],
 			[
 				'script',

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -349,7 +349,8 @@ module.exports = (async function () {
 				'meta',
 				{
 					property: 'og:image',
-					content: '/favicon.ico',
+					content:
+						'https://wiki.bedrock.dev/assets/images/homepage/wikilogo.png',
 				},
 			],
 			[

--- a/docs/.vitepress/theme/Components/Layout.vue
+++ b/docs/.vitepress/theme/Components/Layout.vue
@@ -132,8 +132,6 @@ const data = reactive({ isCookiesAgreed: true })
 onMounted(() => {
 	data.isCookiesAgreed = document.cookie.includes('bedrock-cookies=true')
 
-	console.log(document)
-
 	// create OpenGraph data
 	ogCreate()
 })

--- a/docs/.vitepress/theme/Components/Layout.vue
+++ b/docs/.vitepress/theme/Components/Layout.vue
@@ -4,11 +4,9 @@
 		<Sidebar />
 
 		<main
+			class="m-8 mt-22 min-h-screen"
 			:class="{
-				'm-8': true,
 				'md:ml-80': isVisible,
-				'mt-22': true,
-				'min-h-screen': true,
 			}"
 		>
 			<h1 class="xl:pr-72" v-if="page && page.title" id="top">
@@ -32,9 +30,13 @@
 
 			<div v-if="showContributors">
 				<h2
+				class=''
 					:class="{
-						'xl:mr-72': showToc
-					}">Contributors</h2>
+						'xl:mr-72': showToc,
+					}"
+				>
+					Contributors
+				</h2>
 				<Suspense>
 					<template #default>
 						<Contributors :mentioned="mentionedContributors" />
@@ -46,15 +48,14 @@
 					</template>
 				</Suspense>
 			</div>
-			<div class="float" :hidden="data.isCookiesAgreed"> <!-- Cookie policy -->
+			<div class="float" :hidden="data.isCookiesAgreed">
+				<!-- Cookie policy -->
 				<span>
 					We use cookies to improve your experience. By continuing to
-					use this site, you agree to our use of cookies.
-					See our <a href="/privacy">Privacy Policy</a> for more information.
+					use this site, you agree to our use of cookies. See our
+					<a href="/privacy">Privacy Policy</a> for more information.
 				</span>
-				<Button @click="agreeCookies">
-					Got it!
-				</Button>
+				<Button @click="agreeCookies"> Got it! </Button>
 			</div>
 			<footer class="mainfooter">
 				<div>
@@ -64,7 +65,7 @@
 						target="_blank"
 						rel="noopener noreferrer"
 						>Bedrock-OSS</a
-					>. 
+					>.
 				</div>
 				<div>
 					"Minecraft" is a trademark of Mojang AB. Bedrock-OSS,
@@ -89,7 +90,10 @@
 						>
 					</li>
 					<li>
-						<a href="https://github.com/Bedrock-OSS/bedrock-wiki" target="_blank" rel="noopener noreferrer"
+						<a
+							href="https://github.com/Bedrock-OSS/bedrock-wiki"
+							target="_blank"
+							rel="noopener noreferrer"
 							>Visit our Project Repository!</a
 						>
 					</li>
@@ -116,7 +120,7 @@ import TOC from './Content/TOC.vue'
 import Sidebar from './Sidebar/Sidebar.vue'
 import NavBar from './Navigation/NavBar.vue'
 import { useSidebarState } from '../Composables/sidebar'
-import { useData, useRoute } from 'vitepress'
+import { Content, useData, useRoute } from 'vitepress'
 import Label from './Content/Label.vue'
 import Button from './Content/Button.vue'
 
@@ -124,16 +128,49 @@ const Contributors = defineAsyncComponent(
 	() => import('./Content/Contributors.vue')
 )
 
-const data = reactive({isCookiesAgreed: true});
+const data = reactive({ isCookiesAgreed: true })
 onMounted(() => {
-	data.isCookiesAgreed = document.cookie.includes('bedrock-cookies=true');
-});
+	data.isCookiesAgreed = document.cookie.includes('bedrock-cookies=true')
+
+	console.log(document)
+
+	// create OpenGraph data
+	ogCreate()
+})
 
 const route = useRoute()
 const { page } = useData()
 const { toggle, isVisible } = useSidebarState()
 
+// open graph metadata: used for link previews in eg. discord
+// This method is a bit hacky, because it manually injects the metadata in the pages head.
+let ogCreate = () => {
+	// standard values will stay the same
+	// they are defined in config.js
+	// og:type, og:site_name, og:image
+	let ogTags = {
+		'og:url':
+			page.value.relativePath != ''
+				? `https://wiki.bedrock.dev/${page.value.relativePath.slice(
+						0,
+						page.value.relativePath.lastIndexOf('.md')
+				  )}.html`
+				: 'https://wiki.bedrock.dev',
+		'og:title':
+			page.value.title != '' ? page.value.title : 'The Bedrock Wiki',
+		'og:description':
+			page.value.description != ''
+				? page.value.description
+				: 'This wiki is a knowledge-sharing website for Technical Bedrock, containing documentation, tutorials, and general how-to information.',
+	}
 
+	Object.entries(ogTags).forEach(([name, content]) => {
+		let meta = document.createElement('meta')
+		meta.name = name
+		meta.content = content
+		document.head.appendChild(meta)
+	})
+}
 
 function agreeCookies() {
 	document.cookie = 'bedrock-cookies=true; max-age=31536000 ; path=/'


### PR DESCRIPTION
#137 (#535)


This PR finally brings the OpenGraph metadata for our wiki.

Currently, the website uses the `title` title as `og:title` and the pages `description` as `og:description`. Both of these values are defined via the frontmatter of the wiki pages, but currently no page uses the `description` tag, so the wiki falls back to a default description.

The `og:image` is currently always set to the default image of the wiki.

The `og:url` dynamically references the page that was mentioned.

If there is anything you want to see in the pages metadata, tell it! It could be possible to dynamically create an image or a better url, but i first need feedback on this feature, as it took me a long time to figure out, how to inject metadata manually into the pages.