### PR TITLE
Cancel chat message before running command

### DIFF
--- a/docs/scripting/custom-command.md
+++ b/docs/scripting/custom-command.md
@@ -86,13 +86,13 @@ First, we're gonna add simple commands, such as `!gmc` to change our Gamemode to
 world.events.beforeChat.subscribe(async (eventData) => {
 	const player = eventData.sender;
 	switch (eventData.message) {
-		case '!gmc': 
-			await player.runCommandAsync('gamemode c');
+		case '!gmc':
 			eventData.cancel = true;
+			await player.runCommandAsync('gamemode c');
 			break;
 		case '!gms':
-			await player.runCommandAsync('gamemode s');
 			eventData.cancel = true;
+			await player.runCommandAsync('gamemode s');
 			break;
 		default: break;
 	}


### PR DESCRIPTION
When using the example in custom-command.md the chat message is still displayed:

![IMG_20221028_105121](https://user-images.githubusercontent.com/81803926/198549943-b21df860-71ba-4444-80d3-5c48714d0f28.jpg)

I fixed this by running `eventData.cancel = true;` first:

![Screenshot_2022-10-28-10-53-08-87_5c8300b655012b1930f2e0a7b81bf6a9](https://user-images.githubusercontent.com/81803926/198550198-5e40fb4f-728c-4362-9696-086daabdb8aa.jpg)

This was tested in version 1.19.40.02 on Android.