### PR TITLE
Updated Custom Boats Page with Format Version Info

### DIFF
--- a/docs/entities/boat-entities.md
+++ b/docs/entities/boat-entities.md
@@ -5,11 +5,10 @@ tags:
     - recipe
     - intermediate
 ---
+:::warning Requires Format Version 1.16.100 or Lower
 
-## Requires Format Version 1.16.100 or Lower
-
-The behavior format version now requires 1.16.100 or lower for the `minecraft:behavior.rise_to_liquid_leve` and `minecraft:buoyant` methods to work.
-If you find a new method that works in the newer format versions, you should consider helping to contribute by updating the wiki.
+The behavior format version now requires 1.16.100 or lower for the `minecraft:behavior.rise_to_liquid_level` and `minecraft:buoyant` methods to work.
+If you find a new method that works in the newer format versions, you should consider helping to contribute by updating the wiki. :::
 
 ## Using Runtime Identifiers
 

--- a/docs/entities/boat-entities.md
+++ b/docs/entities/boat-entities.md
@@ -6,9 +6,9 @@ tags:
     - intermediate
 ---
 
-## Requires Format Version 1.16.100 or below
+## Requires Format Version 1.16.100 or Lower
 
-The behavior format version now requires 1.16.100 or below for the `minecraft:behavior.rise_to_liquid_leve` and `minecraft:buoyant` methods to work.
+The behavior format version now requires 1.16.100 or lower for the `minecraft:behavior.rise_to_liquid_leve` and `minecraft:buoyant` methods to work.
 If you find a new method that works in the newer format versions, you should consider helping to contribute by updating the wiki.
 
 ## Using Runtime Identifiers

--- a/docs/entities/boat-entities.md
+++ b/docs/entities/boat-entities.md
@@ -6,6 +6,11 @@ tags:
     - intermediate
 ---
 
+## Requires Format Version 1.16.100
+
+The behavior format version now requires 1.16.100 for the `minecraft:behavior.rise_to_liquid_leve` and `minecraft:buoyant` methods to work.
+If you find a new method that works in the newer format versions, you should consider helping to contribute by updating the wiki.
+
 ## Using Runtime Identifiers
 
 You can read more about runtime identifiers [here](/entities/runtime-identifier). Using runtime identifiers, you can implement most of the boat's hard-coded behaviors. However, your boat won't rotate with you, and it will always face North.

--- a/docs/entities/boat-entities.md
+++ b/docs/entities/boat-entities.md
@@ -6,9 +6,9 @@ tags:
     - intermediate
 ---
 
-## Requires Format Version 1.16.100
+## Requires Format Version 1.16.100 or below
 
-The behavior format version now requires 1.16.100 for the `minecraft:behavior.rise_to_liquid_leve` and `minecraft:buoyant` methods to work.
+The behavior format version now requires 1.16.100 or below for the `minecraft:behavior.rise_to_liquid_leve` and `minecraft:buoyant` methods to work.
 If you find a new method that works in the newer format versions, you should consider helping to contribute by updating the wiki.
 
 ## Using Runtime Identifiers


### PR DESCRIPTION
In 1.19.50 newer format versions break custom boats that work on the water using the `minecraft:behavior.rise_to_liquid_leve` and `minecraft:buoyant` methods.

You should use format version 1.16.100 as a workaround until new methods are discovered.