### PR TITLE
Update throwable.md

### DIFF
--- a/docs/items/throwable.md
+++ b/docs/items/throwable.md
@@ -201,6 +201,14 @@ Now, you have to register the animation controller to the `player.json` file:
         "throwables_controller": "controller.animation.player.throwables" // ID as referenced in animation controller file
       }
     },
+    "components": {
+        "minecraft:breathable": { // keeps breath timer bubbles from appearing 
+          "total_supply": 15,
+          "suffocate_time": -1,
+          "inhale_time": 3.75,
+          "generates_bubbles": false
+    	}
+    },
     ...
   }
 ```


### PR DESCRIPTION
Did the demo, got breath timer in a flat world. Without the component outside its setter component_group, the default is underwater instead of surface. I think it makes the transition faster in water. its no issue because it resets properly the moment player swims