### PR TITLE
Updating Scripting pages to 1.19.80

### DIFF
--- a/docs/blocks/custom-fluids.md
+++ b/docs/blocks/custom-fluids.md
@@ -806,10 +806,10 @@ mc.world.events.tick.subscribe(() => {
     for (let p = 0; p < players.length; p++) {
         for (let i = 0; i < fluidsIDs.length; i++) {
             if (mc.world.getDimension(players[p].dimension.id).getBlock(new mc.BlockLocation(Math.floor(players[p].location.x), players[p].location.y+1.7, Math.floor(players[p].location.z))).typeId == fluidsIDs[i]) {
-                players[p].runCommandAsync("fog @s push fluid:water_fog fluid_fog")
+                players[p].runCommand("fog @s push fluid:water_fog fluid_fog")
                 break
             } else {
-                players[p].runCommandAsync("fog @s remove fluid_fog")
+                players[p].runCommand("fog @s remove fluid_fog")
             }
         }
     }

--- a/docs/scripting/custom-command.md
+++ b/docs/scripting/custom-command.md
@@ -7,7 +7,7 @@ mentions:
 	- cda94581
 ---
 ::: warning
-The Script API is currently in active development, and breaking changes are frequent. This page assumes the format of Minecraft beta 1.19.70
+The Script API is currently in active development, and breaking changes are frequent. This page assumes the format of Minecraft 1.19.80
 :::
 
 Who doesn't want cool custom commands? With the Script API, you can create your own. In this article, we will be creating them using the Script API.
@@ -52,7 +52,7 @@ Assuming you have understood the basics of scripting, let's start creating the p
 		{
 			// Minecraft native module - needed to use the "@minecraft/server" module
 			"module_name": "@minecraft/server",
-			"version": "1.1.0-beta"
+			"version": "1.2.0-beta"
 		}
   ]
 }
@@ -83,16 +83,16 @@ Next, we will add simple commands, such as `!gmc` to change our gamemode to crea
 <CodeHeader>BP/scripts/index.js</CodeHeader>
 
 ```js
-world.events.beforeChat.subscribe(async (eventData) => {
+world.events.beforeChat.subscribe((eventData) => {
 	const player = eventData.sender;
 	switch (eventData.message) {
 		case '!gmc':
 			eventData.cancel = true;
-			await player.runCommandAsync('gamemode c');
+			player.runCommand('gamemode c');
 			break;
 		case '!gms':
 			eventData.cancel = true;
-			await player.runCommandAsync('gamemode s');
+			player.runCommand('gamemode s');
 			break;
 		default: break;
 	}
@@ -103,7 +103,7 @@ This is the main function to execute our commands. `world.events.beforeChat.subs
 - A `switch` statement runs through the possible options for the value, and if it matches, runs the code until the next `break` statement.
 - `eventData.cancel = true` will cancel the chat message that will be sent- similar to how vanilla commands work.
 - `const player = eventData.sender` declares the variable `player` to be used later.
-- `await player.runCommandAsync('gamemode c')` runs the command on the sender of the message.
+- `player.runCommand('gamemode c')` runs the command on the sender of the message.
 
 ## Limited Command Usage by Tags
 
@@ -114,17 +114,17 @@ For example, let's make our commands usable only to players that have the `Admin
 <CodeHeader>BP/scripts/index.js</CodeHeader>
 
 ```js
-world.events.beforeChat.subscribe(async (eventData) => {
+world.events.beforeChat.subscribe((eventData) => {
 	const player = eventData.sender;
 	if (!player.hasTag('Admin')) return;
 	switch (eventData.message) {
 		case '!gmc':
 			eventData.cancel = true;
-			await player.runCommandAsync('gamemode c');
+			player.runCommand('gamemode c');
 			break;
 		case '!gms':
 			eventData.cancel = true;
-			await player.runCommandAsync('gamemode s');
+			player.runCommand('gamemode s');
 			break;
 		default: break;
 	}

--- a/docs/scripting/game-tests.md
+++ b/docs/scripting/game-tests.md
@@ -8,7 +8,7 @@ mentions:
 ---
 
 ::: warning
-The Script API is currently in active development, and breaking changes are frequent. This page assumes the format of Minecraft beta 1.19.70
+The Script API is currently in active development, and breaking changes are frequent. This page assumes the format of Minecraft 1.19.80
 :::
 
 The GameTest Framework allows us to create unit tests ("GameTests") which make it easier to test if game mechanics work.
@@ -38,7 +38,7 @@ To use the GameTest Framework, the `@minecraft/server-gametest` module is requir
 "dependencies": [
     {
         "module_name": "@minecraft/server",
-        "version": "1.1.0-beta"
+        "version": "1.2.0-beta"
     },
     {
         "module_name": "@minecraft/server-gametest",

--- a/docs/scripting/gametest-form.md
+++ b/docs/scripting/gametest-form.md
@@ -8,7 +8,7 @@ mentions:
 ---
 
 ::: warning
-The Script API is currently in active development, and breaking changes are frequent. This page assumes the format of Minecraft beta 1.19.70
+The Script API is currently in active development, and breaking changes are frequent. This page assumes the format of Minecraft 1.19.80
 :::
 
 In version 1.18.30, Minecraft released a wonderful new script module, `@minecraft/server-ui` (formerly named `mojang-minecraft-ui`). With this module, we can create form UIs without the need for JSON UI-wrangling.
@@ -25,7 +25,7 @@ Like other modules, you will need to add the dependency into your `manifest.json
 		},
 		{
 			"module_name": "@minecraft/server",
-			"version": "1.1.0-beta"
+			"version": "1.2.0-beta"
 		}
 	]
 }

--- a/docs/scripting/script-net.md
+++ b/docs/scripting/script-net.md
@@ -6,7 +6,7 @@ tags:
 ---
 
 ::: warning
-The Script API is currently in active development, and breaking changes are frequent. This page assumes the format of Minecraft beta 1.19.70
+The Script API is currently in active development, and breaking changes are frequent. This page assumes the format of Minecraft 1.19.80
 :::
 
 ::: warning

--- a/docs/scripting/script-server.md
+++ b/docs/scripting/script-server.md
@@ -6,7 +6,7 @@ tags:
 ---
 
 ::: warning
-The Script API is currently in active development, and breaking changes are frequent. This page assumes the format of Minecraft beta 1.19.70
+The Script API is currently in active development, and breaking changes are frequent. This page assumes the format of Minecraft 1.19.80
 :::
 
 In Scripting API, most of the core features are implemented in the `@minecraft/server` module, with lots of methods to interact a Minecraft world, including entities, blocks, dimensions, and more programmatically. This article contains a basic introduction to some of the core API mechanics, for more detailed information please visit [Microsoft docs](https://learn.microsoft.com/en-us/minecraft/creator/scriptapi/minecraft/server/minecraft-server).

--- a/docs/scripting/starting-scripts.md
+++ b/docs/scripting/starting-scripts.md
@@ -6,7 +6,7 @@ mentions:
 ---
 
 ::: warning
-The Script API is currently in active development, and breaking changes are frequent. This page assumes the format of Minecraft beta 1.19.70
+The Script API is currently in active development, and breaking changes are frequent. This page assumes the format of Minecraft 1.19.80
 :::
 
 ## Overview
@@ -69,7 +69,7 @@ This problem causes Minecraft to stop the scripts from running and throws error 
 "dependencies": [
 	{
 		"module_name": "@minecraft/server",
-		"version": "1.1.0-beta"
+		"version": "1.2.0-beta"
 	},
 	{
 		"module_name": "@minecraft/server-ui",
@@ -95,12 +95,13 @@ Script API modules all have their own versions and since 1.19.20 they follow sem
 	**Stable API modules**, these do not require the Beta APIs experiment to be turned on. The initial API set is narrow, but more features will be added over the coming months.
 
 	-	`@minecraft/server`:
+		-	`1.1.0`
 		- `1.0.0`
 
 	**Beta API modules**, requires the Beta APIs experiment to be turned on in world settings, with lots of experimental features in the API.
 	
 	-	`@minecraft/server`:
-		-	`1.1.0-beta`
+		-	`1.2.0-beta`
 		-	`0.1.0` (use `mojang-minecraft`, NOT `@minecraft/server` when importing module for this version)
 
 	-	`@minecraft/server-ui`:
@@ -127,7 +128,7 @@ Do not add `"uuid"` and `"module_name"` properties into dependency, add one or t
 ```json
 {
 	"module_name": "@minecraft/server",
-	"version": "1.1.0-beta"
+	"version": "1.2.0-beta"
 }
 ```
 
@@ -165,7 +166,7 @@ system.runInterval(() => {
 
 	// or run a command in overworld dimension
 	// using native API methods (such as world.sendMessage) are recommended whenever possible.
-	world.getDimension("overworld").runCommandAsync("say Hello World");
+	world.getDimension("overworld").runCommand("say Hello World");
 });
 ```
 

--- a/docs/scripting/what-is-script.md
+++ b/docs/scripting/what-is-script.md
@@ -8,7 +8,7 @@ mentions:
 ---
 
 ::: warning
-The Script API is currently in active development, and breaking changes are frequent. This page assumes the format of Minecraft beta 1.19.70
+The Script API is currently in active development, and breaking changes are frequent. This page assumes the format of Minecraft 1.19.80
 :::
 
 ## API


### PR DESCRIPTION
- Replace beta 1.19.70 to 1.19.80
- Update minecraft/server module in manifest.
- Convert all `runCommandAsync` to `runCommand` in code snippets.

-----
TODO

- Still don't know if the developers prefer `runCommandAsync` over `runCommand`
- Document runCommand vs runCommandAsync
- Document existance Editor API modules, not going through in depth.